### PR TITLE
added command line flag for map width

### DIFF
--- a/disperseNN2/data_generation.py
+++ b/disperseNN2/data_generation.py
@@ -25,6 +25,7 @@ class DataGenerator(tf.keras.utils.Sequence):
     shuffle_datasets: bool
     shuffle_individuals: bool
     rho: float
+    w: float
     baseseed: int
     recapitate: bool
     skip_mutate: bool
@@ -174,7 +175,10 @@ class DataGenerator(tf.keras.utils.Sequence):
         np.random.seed(seed)
 
         # grab map width and sigma from provenance
-        W = parse_provenance(ts, "W")
+        if self.w == None:
+            W = parse_provenance(ts, "W")
+        else:
+            W = float(self.w)
         if self.edge_width == "sigma":
             edge_width = parse_provenance(ts, "sigma")
         else:

--- a/disperseNN2/disperseNN2.py
+++ b/disperseNN2/disperseNN2.py
@@ -95,6 +95,12 @@ parser.add_argument(
     default=1e-8,
     type=float)
 parser.add_argument(
+    "--w",
+    default=None,
+    type=int,
+    help="map width (will try to parse automatically if \"W\" provided to SLiM)",
+)
+parser.add_argument(
     "--num_samples",
     default=1,
     type=int,
@@ -428,6 +434,7 @@ def make_generator_params_dict(
         "shuffle_datasets": shuffle_datasets,
         "shuffle_individuals": args.no_shuffle_individuals,
         "rho": args.rho,
+        "w": args.w,
         "baseseed": args.seed,
         "recapitate": args.recapitate,
         "skip_mutate": args.skip_mutate,


### PR DESCRIPTION
These are small changes to give a command line flag for map width.

Before, we parsed this value from the tree sequence "provenance"; this works if you run our slim script with the "W" parameter, but not otherwise (e.g., running slim with a habitat map).

